### PR TITLE
update uuid to v9.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poynt",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "poynt",
-      "version": "0.0.43",
+      "version": "0.0.44",
       "license": "MIT",
       "dependencies": {
         "async": "^2.5.0",
@@ -14,7 +14,7 @@
         "ff": "^0.2.2",
         "jsonwebtoken": "^7.4.3",
         "request": "^2.81.0",
-        "uuid": "^3.1.0",
+        "uuid": "^9.0.1",
         "validator": "^13.7.0"
       },
       "devDependencies": {}
@@ -521,6 +521,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -626,13 +635,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validator": {
@@ -1033,6 +1044,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "safe-buffer": {
@@ -1100,9 +1118,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "validator": {
       "version": "13.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poynt",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Poynt Node.js SDK",
   "main": "lib/index.js",
   "dependencies": {
@@ -9,7 +9,7 @@
     "ff": "^0.2.2",
     "jsonwebtoken": "^7.4.3",
     "request": "^2.81.0",
-    "uuid": "^3.1.0",
+    "uuid": "^9.0.1",
     "validator": "^13.7.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
Seeing this error when trying to use poynt sdk in Lambda
```
2024-10-02T19:35:58.169Z	undefined	ERROR	Uncaught Exception 	
{
    "errorType": "Error",
    "errorMessage": "Package subpath './v4' is not defined by \"exports\" in /var/task/lib/node_modules/uuid/package.json",
    "code": "ERR_PACKAGE_PATH_NOT_EXPORTED",
    "stack": [
        "Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined by \"exports\" in /var/task/lib/node_modules/uuid/package.json",
        "    at new NodeError (node:internal/errors:405:5)",
        "    at exportsNotFound (node:internal/modules/esm/resolve:371:10)",
        "    at packageExportsResolve (node:internal/modules/esm/resolve:718:9)",
        "    at resolveExports (node:internal/modules/cjs/loader:590:36)",
        "    at Module._findPath (node:internal/modules/cjs/loader:664:31)",
        "    at Module._resolveFilename (node:internal/modules/cjs/loader:1126:27)",
        "    at Module._load (node:internal/modules/cjs/loader:981:27)",
        "    at Module.require (node:internal/modules/cjs/loader:1231:19)",
        "    at require (node:internal/modules/helpers:177:18)",
        "    at Object.<anonymous> (/var/task/lib/node_modules/request/lib/auth.js:4:12)"
    ]
}
```
bumping uuid version seems to fix it.

Validated with the following PR: https://github.com/gdcorp-commerce/gopay/pull/1041